### PR TITLE
Implement-fee-recipient-address

### DIFF
--- a/build/entrypoint.sh
+++ b/build/entrypoint.sh
@@ -67,4 +67,5 @@ exec -c /home/user/nimbus-eth2/build/nimbus_beacon_node \
     --keymanager-address=0.0.0.0 \
     --keymanager-token-file=${TOKEN_FILE} \
     --graffiti=\"$GRAFFITI\" \
+    --suggested-fee-recipient="${FEE_RECIPIENT_ADDRESS}" \
     $EXTRA_OPTS

--- a/setup-wizard.yml
+++ b/setup-wizard.yml
@@ -38,4 +38,15 @@ fields:
       It's a good idea to add a backup web3 provider in case your main one goes down. For example, if your primary EL client is a local Geth, but you want to use Infura as a backup.
       Get your web3 backup from [infura](https://infura.io/) (i.e https://XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX@eth.mainnet.infura.io)
     required: false
+  - id: feeRecipientAddress
+    target:
+      type: environment
+      name: FEE_RECIPIENT_ADDRESS
+      service: beacon-validator
+    title: Fee Recipient Address
+    description: >-
+      Fee Recipient is a feature that lets you specify a priority fee recipient address on your validator client instance and beacon node. After The Merge, execution clients will begin depositing priority fees into this address whenever your validator client proposes a new block.
+    required: true
+    pattern: "^0x[a-fA-F0-9]{40}$"
+    patternErrorMessage: Must be a valid address (0x1fd16a...)
   


### PR DESCRIPTION
Implement fee recipient address during installation through the setup-wizard

For consistency, this value should be set in both services: beacon-chain and validator. See https://github.com/dappnode/DAppNodeSDK/issues/238