### PR TITLE
Remove gorli as a dependency

### DIFF
--- a/dappnode_package.json
+++ b/dappnode_package.json
@@ -37,7 +37,6 @@
     "portNumber": 4500
   },
   "dependencies": {
-    "web3signer-prater.dnp.dappnode.eth": "latest",
-    "goerli-geth.dnp.dappnode.eth": "latest"
+    "web3signer-prater.dnp.dappnode.eth": "latest"
   }
 }


### PR DESCRIPTION
Remove the dependency goerli and allow users to select the EL with a well definition in the sertupwizard with the available EL clients